### PR TITLE
Skipping a commit for tagging and deployment

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Bump version and push tag
         if: |
           github.event.name == 'push' && 
-          !contains(join(github.event.commits.*.message, ' '), 'skip')
+          !contains(join(github.event.commits.*.message, ' '), '#skip')
         uses: anothrNick/github-tag-action@1.33.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
       - name: deploy to heroku
         if: |
           github.event.name == 'push' && 
-          !contains(join(github.event.commits.*.message, ' '), 'skip')
+          !contains(join(github.event.commits.*.message, ' '), '#skip')
         uses: akhileshns/heroku-deploy@v3.12.12
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}


### PR DESCRIPTION
Skips the deploy step and the tagging step if '#skip' is present in the commit message.